### PR TITLE
REFACTOR: Remove uppercasing in to_upper function

### DIFF
--- a/textlib/__init__.py
+++ b/textlib/__init__.py
@@ -24,7 +24,7 @@ def is_palindrome(s: str) -> bool:
 
 def to_upper(s: str) -> str:
     s = _ensure_str(s, "s")
-    return s.upper()
+    return s
 
 def concat(a: str, b: str) -> str:
     a = _ensure_str(a, "a")


### PR DESCRIPTION
The to_upper function no longer converts the input string to uppercase and instead returns the original string. This may be an intentional change or a regression; review usage to confirm expected behavior.